### PR TITLE
dockerfileにpython追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:16.13.1-alpine
 
+RUN apk update && apk add  make gcc g++ python3
+
 ARG API_URL
 
 ENV LANG=C.UTF-8 \


### PR DESCRIPTION
ある時を境に、npm installのコマンド実行時にエラーが出るようになった

pythonが不足しているとのことだったので、Dockerfileに追記する